### PR TITLE
Use a pointer to state in _update and _final

### DIFF
--- a/advanced/sha-2_hash_function.md
+++ b/advanced/sha-2_hash_function.md
@@ -34,9 +34,9 @@ unsigned char out[crypto_hash_sha256_BYTES];
 crypto_hash_sha256_state state;
 
 crypto_hash_sha256_init(&state);
-crypto_hash_sha256_update(state, MESSAGE_PART1, MESSAGE_PART1_LEN);
-crypto_hash_sha256_update(state, MESSAGE_PART2, MESSAGE_PART2_LEN);
-crypto_hash_sha256_final(state, out);
+crypto_hash_sha256_update(&state, MESSAGE_PART1, MESSAGE_PART1_LEN);
+crypto_hash_sha256_update(&state, MESSAGE_PART2, MESSAGE_PART2_LEN);
+crypto_hash_sha256_final(&state, out);
 ```
 
 ## Usage


### PR DESCRIPTION
The functions `crypto_hash_sha256_update` and `crypto_hash_sha256_final` take a
pointer to `state` as their first arguments, however the documentation showed
an example of passing state directly by-value.  This is incorrect and won't
compile.  This patch corrects the documentation by passing a pointer.
