### PR TITLE
Update scalar_multiplication.md

### DIFF
--- a/advanced/scalar_multiplication.md
+++ b/advanced/scalar_multiplication.md
@@ -18,7 +18,7 @@ int crypto_scalarmult(unsigned char *q, const unsigned char *n,
 ```
 This function can be used to compute a shared secret given a user's secret key and another user's public key.
 
-`n` and `p` are `crypto_scalarmult_SCALARBYTES` bytes long, and the output size is `crypto_scalarmult_BYTES` bytes.
+`n` is `crypto_scalarmult_SCALARBYTES` bytes long, `p` and the output are `crypto_scalarmult_BYTES` bytes long.
 
 Instead of directly using the output of the multiplication `q` as a shared key, it is recommended to use `h(q || pk1 || pk2)`, with `pk1` and `pk2` being the public keys.
 


### PR DESCRIPTION
`p` is not `crypto_scalarmult_SCALARBYTES` bytes long.
ok, it is.. but just for consistency :)