### PR TITLE
Fix typo in key_derivation (2)

### DIFF
--- a/key_derivation/README.md
+++ b/key_derivation/README.md
@@ -25,7 +25,7 @@ Example:
 ```c
 #define CONTEXT "Examples"
 
-uint8_t master_key[hydro_kdf_KEYBYTES];
+uint8_t master_key[crypto_kdf_KEYBYTES];
 uint8_t subkey1[32];
 uint8_t subkey2[32];
 uint8_t subkey3[64];


### PR DESCRIPTION
I missed this typo in my [previous pull request](https://github.com/jedisct1/libsodium-doc/pull/32).