### PR TITLE
Add note on `sodium_malloc` return value

### DIFF
--- a/helpers/memory_management.md
+++ b/helpers/memory_management.md
@@ -64,7 +64,9 @@ void *sodium_malloc(size_t size);
 ```
 
 The `sodium_malloc()` function returns a pointer from which exactly `size`
-contiguous bytes of memory can be accessed.
+contiguous bytes of memory can be accessed. Like normal `malloc`, `NULL`
+may be returned and `errno` set if it is not possible to allocate enough
+memory.
 
 The allocated region is placed at the end of a page boundary, immediately
 followed by a guard page. As a result, accessing memory past the end of the


### PR DESCRIPTION
I found this by reading the source, however I'm not sure `errno` is always set. Following this code path, it seems that `NULL` may be returned, but `errno` is not set: 

https://github.com/jedisct1/libsodium/blob/69642f040935d9458ea3d2ba83696751c24bc13a/src/libsodium/sodium/utils.c#L538-L540