### PR TITLE
Minor clarifications on AEAD APIs

### DIFF
--- a/secret-key_cryptography/aead.md
+++ b/secret-key_cryptography/aead.md
@@ -7,7 +7,7 @@ This operation:
   message, as well as optional, non-confidential \(non-encrypted\) data, haven't
   been tampered with.
 
-A typical use case for additional data is to store protocol-specific metadata
+A typical use case for additional data is to authenticate protocol-specific metadata
 about the message, such as its length and encoding.
 
 ## Supported constructions

--- a/secret-key_cryptography/aead.md
+++ b/secret-key_cryptography/aead.md
@@ -16,6 +16,10 @@ libsodium supports two popular constructions: AES256-GCM and ChaCha20-Poly1305
 \(original version and IETF version\), as well as a variant of the later with an
 extended nonce: XChaCha20-Poly1305.
 
+The "combined mode" API of each construction appends the
+authentication tag to the ciphertext. The "detached mode" API stores
+the authentication tag in a separate location.
+
 ### Availability and interoperability
 
 | Construction            | Key size | Nonce size | Block size | MAC size | Availability                                                                                                  |

--- a/secret-key_cryptography/aes-256-gcm.md
+++ b/secret-key_cryptography/aes-256-gcm.md
@@ -105,8 +105,8 @@ this function.
 
 ## Combined mode
 
-In combined mode, the authentication tag and the encrypted message are stored
-together. This is usually what you want.
+In combined mode, the authentication tag is directly appended to the
+encrypted message. This is usually what you want.
 
 ```c
 int crypto_aead_aes256gcm_encrypt(unsigned char *c,

--- a/secret-key_cryptography/ietf_chacha20-poly1305_construction.md
+++ b/secret-key_cryptography/ietf_chacha20-poly1305_construction.md
@@ -39,8 +39,8 @@ if (crypto_aead_chacha20poly1305_ietf_decrypt(decrypted, &decrypted_len,
 
 ## Combined mode
 
-In combined mode, the authentication tag and the encrypted message are stored
-together. This is usually what you want.
+In combined mode, the authentication tag is directly appended to the
+encrypted message. This is usually what you want.
 
 ```c
 int crypto_aead_chacha20poly1305_ietf_encrypt(unsigned char *c,

--- a/secret-key_cryptography/original_chacha20-poly1305_construction.md
+++ b/secret-key_cryptography/original_chacha20-poly1305_construction.md
@@ -39,8 +39,8 @@ if (crypto_aead_chacha20poly1305_decrypt(decrypted, &decrypted_len,
 
 ## Combined mode
 
-In combined mode, the authentication tag and the encrypted message are stored
-together. This is usually what you want.
+In combined mode, the authentication tag is directly appended to the
+encrypted message. This is usually what you want.
 
 ```c
 int crypto_aead_chacha20poly1305_encrypt(unsigned char *c,

--- a/secret-key_cryptography/xchacha20-poly1305_construction.md
+++ b/secret-key_cryptography/xchacha20-poly1305_construction.md
@@ -45,8 +45,8 @@ if (crypto_aead_xchacha20poly1305_ietf_decrypt(decrypted, &decrypted_len,
 
 ## Combined mode
 
-In combined mode, the authentication tag and the encrypted message are stored
-together. This is usually what you want.
+In combined mode, the authentication tag is directly appended to the
+encrypted message. This is usually what you want.
 
 ```c
 int crypto_aead_xchacha20poly1305_ietf_encrypt(unsigned char *c,


### PR DESCRIPTION
Explicitly say where the authentication tag ends up (while appending the auth tag is the more common choice, prepended auth tags are used at times as well).