### PR TITLE
Add Lazysodium to bindings

### DIFF
--- a/bindings_for_other_languages/README.md
+++ b/bindings_for_other_languages/README.md
@@ -48,9 +48,11 @@
 * Idris: [Sodium-Idris](https://github.com/edwinb/sodium-idris)
 * Java (Java Native Access):
   [libsodium-jna](https://github.com/muquit/libsodium-jna)
+* Java (Android): [Lazysodium for Android](https://github.com/terl/lazysodium-android)
 * Java (Android): [Libstodium](https://github.com/ArteMisc/libstodium)
 * Java (Android): [Robosodium](https://github.com/GerardSoleCa/Robosodium)
 * Java (Android): [libsodium-JNI](https://github.com/joshjdevl/libsodium-jni)
+* Java: [Lazysodium for Java](https://github.com/terl/lazysodium-java)
 * Java: [jsodium](https://github.com/naphaso/jsodium)
 * Java: [Kalium](https://github.com/abstractj/kalium)
 * Java: [sodium-jni](https://github.com/JackWink/sodium-jni)


### PR DESCRIPTION
Hello!

I've noticed that there isn't a library that provides a similar kind of API for both Android and Java. One that also makes it easier for devs to have a stress-free and effortless experience with cryptography. So I created Lazysodium. 

Lazysodium makes it easier for devs to get started with Libsodium (and therefore cryptography in general). I suppose you could say it makes devs so productive that they can afford to be lazy 😅 but let's not tell our bosses that!

Thanks!