### PR TITLE
Add ConsenSys Cava java binding.

### DIFF
--- a/bindings_for_other_languages/README.md
+++ b/bindings_for_other_languages/README.md
@@ -53,6 +53,7 @@
 * Java (Android): [Libstodium](https://github.com/ArteMisc/libstodium)
 * Java (Android): [Robosodium](https://github.com/GerardSoleCa/Robosodium)
 * Java (Android): [libsodium-JNI](https://github.com/joshjdevl/libsodium-jni)
+* Java: [ConsenSys Cava](https://github.com/ConsenSys/cava) ([crypto module](https://consensys.github.io/cava/docs/java/latest/net/consensys/cava/crypto/sodium/package-summary.html))
 * Java: [Lazysodium for Java](https://github.com/terl/lazysodium-java)
 * Java: [jsodium](https://github.com/naphaso/jsodium)
 * Java: [Kalium](https://github.com/abstractj/kalium)


### PR DESCRIPTION
ConsenSys Cava (consensys libraries for java) includes a module with a JNR-FFI interface to the latest libsodium release, presented through a library of object-oriented java primitives.