### PR TITLE
Add Factor to the language list

### DIFF
--- a/bindings_for_other_languages/README.md
+++ b/bindings_for_other_languages/README.md
@@ -5,6 +5,7 @@
 * PHP >= 7.2
 * HHVM >= 3.20
 * [Citrine](https://citrine-lang.org/)
+* [Factor](https://factorcode.org/) >= 0.98
 * [Zion](https://github.com/zionlang/zion)
 
 ## Bindings programming languages


### PR DESCRIPTION
The partial Libsodium API was included in the Factor standard library in March 2017, and subsequently released with v0.98 of the language. Yesterday I've completed the full API bindings, and they [were merged](https://github.com/factor/factor/pull/2086) into the [master branch](https://github.com/factor/factor/tree/master/extra/sodium) for subsequent releases. Currently available in the [development builds](https://factorcode.org/).