### PR TITLE
Add Rebel Backup to the list of applications

### DIFF
--- a/libsodium_users/README.md
+++ b/libsodium_users/README.md
@@ -114,6 +114,7 @@ to add yours to that list.
   application that encrypts files and directories using a symmetric-key
   algorithm.
 * [RavenDB](https://ravendb.net/): A linq enabled document database for .NET.
+* [Rebel Backup](https://www.svsware.com/rebelbackup): Encrypted backups to Dropbox and Google Drive.
 * [Remembear](https://www.remembear.com/): a full-featured, multi-platform
   password manager, by TunnelBear.
 * [Reop](http://www.tedunangst.com/flak/post/reop): Reasonable expectation of

--- a/libsodium_users/README.md
+++ b/libsodium_users/README.md
@@ -114,7 +114,7 @@ to add yours to that list.
   application that encrypts files and directories using a symmetric-key
   algorithm.
 * [RavenDB](https://ravendb.net/): A linq enabled document database for .NET.
-* [Rebel Backup](https://www.svsware.com/rebelbackup): Encrypted backups to Dropbox and Google Drive.
+* [Rebel Backup](https://www.svsware.com/rebelbackup): Encrypted backups of important files to Dropbox and Google Drive.
 * [Remembear](https://www.remembear.com/): a full-featured, multi-platform
   password manager, by TunnelBear.
 * [Reop](http://www.tedunangst.com/flak/post/reop): Reasonable expectation of


### PR DESCRIPTION
Rebel Backup uses libsodium's XChaCha20-Poly1305 for file encryption, and XSalsa20 with Poly1305 for secret key encryption