### PR TITLE
Generating random data: Document use of getrandom(2) on FreeBSD

### DIFF
--- a/generating_random_data/README.md
+++ b/generating_random_data/README.md
@@ -5,7 +5,7 @@ for creating secret keys.
 
 * On Windows systems, the `RtlGenRandom()` function is used
 * On OpenBSD and Bitrig, the `arc4random()` function is used
-* On recent Linux kernels, the `getrandom` system call is used
+* On recent FreeBSD and Linux kernels, the `getrandom` system call is used
 * On other Unices, the `/dev/urandom` device is used
 * If none of these options can safely be used, custom implementations can easily
   be hooked.


### PR DESCRIPTION
Libsodium uses getrandom(2) on recent (2018/12 and newer) versions of FreeBSD, as well as recent
versions of Linux.  So amend the text, which previously incorrectly suggested `/dev/urandom` was used
on FreeBSD.

https://github.com/jedisct1/libsodium/blob/master/src/libsodium/randombytes/internal/randombytes_internal_random.c#L35-L38