### PR TITLE
add null-terminated character

### DIFF
--- a/secret-key_cryptography/aes-256-gcm.md
+++ b/secret-key_cryptography/aes-256-gcm.md
@@ -47,7 +47,7 @@ crypto_aead_aes256gcm_encrypt(ciphertext, &ciphertext_len,
                               ADDITIONAL_DATA, ADDITIONAL_DATA_LEN,
                               NULL, nonce, key);
 
-unsigned char decrypted[MESSAGE_LEN];
+unsigned char decrypted[MESSAGE_LEN + 1];
 unsigned long long decrypted_len;
 if (ciphertext_len < crypto_aead_aes256gcm_ABYTES ||
     crypto_aead_aes256gcm_decrypt(decrypted, &decrypted_len,


### PR DESCRIPTION
#define MESSAGE (const unsigned char *) "test"
the MESSAGE'length is 4, and if wants to store a string "test", we need a char[5] includes a null-terminated character.
which the original code: unsigned char decrypted[MESSAGE_LEN];
changed to unsigned char decrypted[MESSAGE_LEN + 1];