### PR TITLE
docs: Mention Haskell's libsoduim binding

### DIFF
--- a/bindings_for_other_languages/README.md
+++ b/bindings_for_other_languages/README.md
@@ -41,6 +41,7 @@
 * Go: [libsodium-go](https://github.com/GoKillers/libsodium-go)
 * Go: [Sodium](https://github.com/jamesruan/sodium)
 * Guile: [Guile-NaCl](https://github.com/cryptotronix/guile-nacl)
+* Haskell: [libsodium](https://hackage.haskell.org/package/libsodium) 
 * Haskell: [haskell-libsodium](https://github.com/dmp1ce/haskell-libsodium)
 * Haskell: [Saltine](https://github.com/tel/saltine)
 * Haskell: [Lithium](https://github.com/eth-r/lithium)


### PR DESCRIPTION
Haskell's libsodium is a low-level Haskell binding of the full C libsodium library

https://hackage.haskell.org/package/libsodium