### PR TITLE
Add binding to updated Pharo 7/8 project repository

### DIFF
--- a/bindings_for_other_languages/README.md
+++ b/bindings_for_other_languages/README.md
@@ -93,6 +93,7 @@
 * Perl 6: [Natrium](https://github.com/jonathanstowe/Natrium)
 * Pharo/Squeak:
   [Crypto-NaCl](http://www.eighty-twenty.org/index.cgi/tech/smalltalk/nacl-for-squeak-and-pharo-20130601.html)
+* Pharo 7/8: [Crypto-Nacl](https://github.com/objectguild/Crypto-Nacl)
 * Pony: [Pony-Sodium](https://github.com/jemc/pony-sodium)
 * Python: [Csodium](https://github.com/ereOn/csodium)
 * Python: [LibNaCl](https://github.com/saltstack/libnacl)


### PR DESCRIPTION
Hi Frank,

I've refreshed the original Squeak/Pharo binding by Tony Garnock-Jones for Pharo versions 7.0 and 8.0 and created a GitHub repository for it. Would you be so kind to accept the added link on the bindings page?

Great work you and all contributors are doing on Libsodium, thank you!

Kind regards,
Jonathan 