### PR TITLE
Fix Findsodium.cmake URL in README

### DIFF
--- a/usage/README.md
+++ b/usage/README.md
@@ -27,7 +27,7 @@ For static linking, Visual Studio users should define `SODIUM_STATIC=1` and
 `SODIUM_EXPORT=`. This is not required on other platforms.
 
 Projects using CMake can include the
-[Findsodium.cmake](https://github.com/facebookincubator/fizz/blob/master/fizz/cmake/FindSodium.cmake)
+[Findsodium.cmake](https://github.com/facebookincubator/fizz/blob/master/build/fbcode_builder/CMake/FindSodium.cmake)
 file from the Facebook Fizz project in order to detect and link the library.
 
 `sodium_init()` initializes the library and should be called before any other


### PR DESCRIPTION
The file has been renamed by https://github.com/facebookincubator/fizz/commit/99983646c7c627a24bc42f274aada5d958e248d2#diff-e6c9d3146257f257e2128e57ef772cb3b37b7a8177f289b326638489db473129