### PR TITLE
Add installation from package repos to installation instructions

### DIFF
--- a/installation/README.md
+++ b/installation/README.md
@@ -1,5 +1,20 @@
 # Installation
 
+## Linux
+
+Many Linux distributions include packages which provide Sodium, allowing its
+installation and updating to be handled by the package manager. For example, the
+`libsodium-dev` package provides the library on Debian, and can be installed in
+the standard way:
+
+```sh
+sudo apt install libsodium-dev
+```
+
+If your distribution does not provide a sufficiently recent version of Sodium,
+or you would prefer to compile the library yourself, you can follow the
+instructions for compilation on Unix-like systems.
+
 ## Compilation on Unix-like systems
 
 Sodium is a shared library with a machine-independent set of headers, so that it


### PR DESCRIPTION
Thank you so much for creating Sodium! I'm a big fan of your approach to cryptography with this library.

This commit adds some detail to the installation instructions, pointing Linux users towards the version of Sodium within their package repositories, which may be more convenient for installation/updates. Currently the only installation method on the page relevant to those on Linux would be to compile from scratch, which seems unnecessary when precompiled versions are available.

If there's a reason this has been left out of the installation instructions previously, feel free to close the PR :)