### PR TITLE
advanced/{salsa,chacha}: document return codes for stream functions

### DIFF
--- a/advanced/salsa20.md
+++ b/advanced/salsa20.md
@@ -24,6 +24,8 @@ The `crypto_stream_salsa20()` function stores `clen` pseudo random bytes into
 `c` using a nonce `n` (`crypto_stream_salsa20_NONCEBYTES` bytes) and a secret
 key `k` (`crypto_stream_salsa20_KEYBYTES` bytes).
 
+The function always returns `0`.
+
 ```c
 int crypto_stream_salsa20_xor(unsigned char *c, const unsigned char *m,
                               unsigned long long mlen, const unsigned char *n,
@@ -41,6 +43,8 @@ authentication tag.
 `m` and `c` can point to the same address (in-place encryption/decryption). If
 they don't, the regions should not overlap.
 
+The function always returns `0`.
+
 ```c
 int crypto_stream_salsa20_xor_ic(unsigned char *c, const unsigned char *m,
                                  unsigned long long mlen,
@@ -57,6 +61,8 @@ ones.
 
 `m` and `c` can point to the same address (in-place encryption/decryption). If
 they don't, the regions should not overlap.
+
+The function always returns `0`.
 
 ```c
 void crypto_stream_salsa20_keygen(unsigned char k[crypto_stream_salsa20_KEYBYTES]);

--- a/advanced/xchacha20.md
+++ b/advanced/xchacha20.md
@@ -27,6 +27,8 @@ The `crypto_stream_xchacha20()` function stores `clen` pseudo random bytes into
 `c` using a nonce `n` (`crypto_stream_xchacha20_NONCEBYTES` bytes) and a secret
 key `k` (`crypto_stream_xchacha20_KEYBYTES` bytes).
 
+The function always returns `0`.
+
 ```c
 int crypto_stream_xchacha20_xor(unsigned char *c, const unsigned char *m,
                                 unsigned long long mlen, const unsigned char *n,
@@ -44,6 +46,8 @@ authentication tag.
 `m` and `c` can point to the same address (in-place encryption/decryption). If
 they don't, the regions should not overlap.
 
+The function always returns `0`.
+
 ```c
 int crypto_stream_xchacha20_xor_ic(unsigned char *c, const unsigned char *m,
                                    unsigned long long mlen,
@@ -60,6 +64,8 @@ ones.
 
 `m` and `c` can point to the same address (in-place encryption/decryption). If
 they don't, the regions should not overlap.
+
+The function always returns `0`.
 
 ```c
 void crypto_stream_xchacha20_keygen(unsigned char k[crypto_stream_xchacha20_KEYBYTES]);

--- a/advanced/xsalsa20.md
+++ b/advanced/xsalsa20.md
@@ -27,6 +27,8 @@ The `crypto_stream()` function stores `clen` pseudo random bytes into `c` using
 a nonce `n` (`crypto_stream_NONCEBYTES` bytes) and a secret key `k`
 (`crypto_stream_KEYBYTES` bytes).
 
+The function always returns `0`.
+
 ```c
 int crypto_stream_xor(unsigned char *c, const unsigned char *m,
                       unsigned long long mlen, const unsigned char *n,
@@ -43,6 +45,8 @@ authentication tag.
 
 `m` and `c` can point to the same address (in-place encryption/decryption). If
 they don't, the regions should not overlap.
+
+The function always returns `0`.
 
 ```c
 void crypto_stream_keygen(unsigned char k[crypto_stream_KEYBYTES]);


### PR DESCRIPTION
At first I was tempted to add some generalized statement to the Usage page about return code conventions in libsodium, but that didn't seem like a good idea.

Perhaps a section "Error handling" on the "Usage" page would be a good idea, along the lines of

> ## Error handling
>
> libsodium distinguishes between errors (e.g. a signature mismatch) and misuse (e.g. trying to encrypt a message longer than the maximum allowed length for a given construction). Errors are handled through the return codes documented for each function, while misuse triggers a call to `abort()` to terminate the program.