### PR TITLE
/MT vs /MD

### DIFF
--- a/installation/README.md
+++ b/installation/README.md
@@ -63,7 +63,7 @@ If the version is out of date, please [create an issue or pull request](https://
 ## Pre-built libraries
 
 [Pre-built x86 and x86_64 libraries for Visual Studio 2017, 2019, and 2022](https://download.libsodium.org/libsodium/releases/)
-with `stable` additions (see below) are available, as well as pre-built libraries for MinGW32 and MinGW64.
+with `stable` additions (see below) are available, as well as pre-built libraries for MinGW32 and MinGW64. Note that pre-built libraries are built with the run-time Multi-threaded (/MT) and not with Multi-threaded DLL (/MD).
 
 They include header files as well as static \(`.LIB`\) and shared \(`.DLL`\)
 libraries for all the supported compiler versions.


### PR DESCRIPTION
pre-built libraries are built with the run-time Multi-threaded (/MT) and not with Multi-threaded DLL (/MD)