### PR TITLE
Change LDFLAGS to LDLIBS

### DIFF
--- a/usage/README.md
+++ b/usage/README.md
@@ -18,7 +18,7 @@ The library is called `sodium` (use `-lsodium` to link it), and proper compilati
 
 ``` bash
 CFLAGS=$(pkg-config --cflags libsodium)
-LDFLAGS=$(pkg-config --libs libsodium)
+LDLIBS=$(pkg-config --libs libsodium)
 ```
 
 For static linking, Visual Studio users should define `SODIUM_STATIC=1` and `SODIUM_EXPORT=`. This is not required on other platforms.


### PR DESCRIPTION
Setting `LDFLAGS` to `$(pkg-config --libs libsodium)` in a makefile results in a linker error, whereas setting `LDLIBS` to the same value works fine

Example makefiles:
```make
# Bad, linker error

CC = gcc
CFLAGS = $$(pkg-config --cflags libsodium)
LDFLAGS = $$(pkg-config --libs libsodium)

.PHONY: all, clean

all: client
clean:
	rm -rvf client client.o

client: client.o ../shared/shared.o
client.o: client.c client.h

# OUTPUT:
# gcc $(pkg-config --libs libsodium)  client.o ../shared/shared.o   -o client
# /usr/bin/ld: ../shared/shared.o: in function `testfunction':
# shared.c:(.text+0x3d9): undefined reference to `sodium_init'
# /usr/bin/ld: shared.c:(.text+0x433): undefined reference to `randombytes_uniform'
# collect2: error: ld returned 1 exit status
# make: *** [<builtin>: client] Error 1
```

```make
# Good, no linker error

CC = gcc
CFLAGS = $$(pkg-config --cflags libsodium)
LDLIBS = $$(pkg-config --libs libsodium)

.PHONY: all, clean

all: client
clean:
	rm -rvf client client.o

client: client.o ../shared/shared.o
client.o: client.c client.h

# OUTPUT:
# gcc   client.o ../shared/shared.o  $(pkg-config --libs libsodium) -o client
```

Note: This is my first contribution to a reasonably large public project. Any constructive criticism is appreciated