### PR TITLE
fix: update the link from Scrypt to Argon2

### DIFF
--- a/password_hashing/scrypt.md
+++ b/password_hashing/scrypt.md
@@ -2,7 +2,7 @@
 
 Sodium provides an implementation of the scrypt password hashing function.
 
-However, unless you have specific reasons to use scrypt, you should instead consider the default function, [Argon2](../password_hashing/the_argon2i_function.md).
+However, unless you have specific reasons to use scrypt, you should instead consider the default function, [Argon2](../password_hashing/default_phf.md).
 
 ## Example 1: key derivation
 


### PR DESCRIPTION
I noticed while looking at https://doc.libsodium.org/advanced/scrypt that the link to Argon2 leads to a missing page.

It seems to have become outdated since https://github.com/jedisct1/libsodium-doc/commit/0abfef68f0e733993bcd0c7dabd944b27ab5bfc4. 