### PR TITLE
Made key exchange algorithm details more explicit

### DIFF
--- a/key_exchange/README.md
+++ b/key_exchange/README.md
@@ -108,8 +108,11 @@ The shared secret key `rx` should be used by the server to receive data from the
 ## Algorithm details
 
 Let `p.n` be the `crypto_scalarmult_curve25519_BYTES` byte output of the X25519 key exchange operation. The 512-bit output of `BLAKE2B-512` is split into two 256-bit keys `crx` and `ctx`.
+
 `crx = stx` and `ctx = srx`.
+
 `crx` being the client reception key and `ctx` the client transmission key.
+
 `srx` being the server reception key and `stx` the server transmission key.
 
 `crx || ctx = BLAKE2B-512(p.n || client_pk || server_pk)`

--- a/key_exchange/README.md
+++ b/key_exchange/README.md
@@ -107,9 +107,12 @@ The shared secret key `rx` should be used by the server to receive data from the
 
 ## Algorithm details
 
-Let `p.n` be the `crypto_scalarmult_curve25519_BYTES` byte output of the X25519 key exchange operation. The 512-bit output of `BLAKE2B-512` is split into two 256-bit keys `rx` and `tx`.
+Let `p.n` be the `crypto_scalarmult_curve25519_BYTES` byte output of the X25519 key exchange operation. The 512-bit output of `BLAKE2B-512` is split into two 256-bit keys `crx` and `ctx`.
+`crx = stx` and `ctx = srx`.
+`crx` being the client reception key and `ctx` the client transmission key.
+`srx` being the server reception key and `stx` the server transmission key.
 
-`rx || tx = BLAKE2B-512(p.n || client_pk || server_pk)`
+`crx || ctx = BLAKE2B-512(p.n || client_pk || server_pk)`
 
 ## Notes
 


### PR DESCRIPTION
Hello,

We noticed the key exchange algorithm details was not explicit from which viewpoint we were talking.
It says `rx` and `tx` but unclear if it is from the client or server point of view.

So we rephrased it to make it clearer it was from the client perspective.

Maybe it was said elsewhere around and we missed it.

Cheers