### PR TITLE
Add nimsodium to Nim bindings

### DIFF
--- a/bindings_for_other_languages/README.md
+++ b/bindings_for_other_languages/README.md
@@ -41,6 +41,7 @@
   - Lean 4: [Sodium](https://github.com/rj-calvin/sodium)
   - Lua: [luasodium](https://github.com/jprjr/luasodium)
   - Nim: [nim-libsodium](https://github.com/BundleFeed/nim-libsodium) (experimental)
+  - Nim: [nimsodium](https://github.com/puffball1567/nimsodium) (high-level wrapper)
   - Perl: [Crypt::Sodium::XS](https://metacpan.org/dist/Crypt-Sodium-XS)
   - PHP: [libsodium-php](https://github.com/jedisct1/libsodium-php)
   - PHP: [dhole-cryptography](https://github.com/soatok/dhole-cryptography)


### PR DESCRIPTION
This adds nimsodium as an additional Nim option on the bindings page.

nimsodium is a high-level Nim wrapper around libsodium focused on safer workflow-oriented APIs. It is already available as a Nimble package and has a v0.2.1 pre-release.

This does not replace the existing nim-libsodium entry; it only adds another Nim option for users looking for a higher-level wrapper.

Repository: https://github.com/puffball1567/nimsodium
Release: https://github.com/puffball1567/nimsodium/releases/tag/v0.2.1
